### PR TITLE
Require APCu extension `^5.1.10`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "license": "BSD-3-Clause",
   "require": {
     "php": "^7.3 || ~8.0.0",
-    "ext-apcu": ">=5.1.0",
+    "ext-apcu": "^5.1.10",
     "laminas/laminas-cache": "^3.0"
   },
   "provide": {


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

Since PHP 8.0, Laminas tries to focus on tested software. Thus said, we also only allow extension versions which we can actually test against. Since we are not really able to test against older versions of extensions (yet), we can at least say that there were no issues with PHP 7.3 starting in `ext-apcu` [v5.1.10](https://pecl.php.net/package/APCu/5.1.10) and thus, that will be the minimum required extension version as of the release of v2.0.