### PR TITLE
Remove dependabot in favor of renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "composer"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    versioning-strategy: increase-if-necessary
-    labels:
-      - "dependency update"


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

Since we now configured renovate, we can remove dependabot.